### PR TITLE
add param confirmed = false

### DIFF
--- a/src/web/routes.coffee
+++ b/src/web/routes.coffee
@@ -40,6 +40,7 @@ module.exports = (
 
 
     params =
+      confirmed: false
       response_type: 'code'
       redirect_uri: redirect_uri
       client_id: client_id


### PR DESCRIPTION
Add param, confirmed = false to make sure the switch user screen is shown when making a login request.
Not working as expected right now, but pushing anyway, in case it's a cookies issue